### PR TITLE
Couple UX improvements

### DIFF
--- a/src/android/PinDialog.java
+++ b/src/android/PinDialog.java
@@ -9,16 +9,14 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.text.InputType;
 import android.text.method.PasswordTransformationMethod;
+import android.view.WindowManager;
 import android.widget.EditText;
 
 
 public class PinDialog extends CordovaPlugin {
-
-    public ProgressDialog spinnerDialog = null;
 
     public PinDialog() {
     }
@@ -108,9 +106,11 @@ public class PinDialog extends CordovaPlugin {
                         }
                     });
 
-                    dlg.create();
-                    dlg.show();
-
+                    AlertDialog instance = dlg.create();
+                    instance.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE|WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
+                    instance.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+                    instance.show();
+                    promptInput.requestFocus();
                 };
             };
             this.cordova.getActivity().runOnUiThread(runnable);

--- a/src/ios/CDVPinDialog.m
+++ b/src/ios/CDVPinDialog.m
@@ -43,7 +43,7 @@
 }
     
     
-- (void)alertView:(UIAlertView*)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+- (void)alertView:(UIAlertView*)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
     CDVPluginResult* result;
 


### PR DESCRIPTION
### iOS

* Wait until dialog is dismissed before sending result back to Cordova app. Without this, certain UI elements that are shown as part of the callback end up being hidden along with the dialog as it gets closed by the OS.

### Android

* Request focus on the text-editor field in the dialog, which brings up the soft-keyboard after opening the dialog. iOS already behaves this way (no fix needed)
